### PR TITLE
Allow disabling offset within hour by supporting negative values in UI

### DIFF
--- a/frontend/src/components/SetupComponent.tsx
+++ b/frontend/src/components/SetupComponent.tsx
@@ -52,23 +52,15 @@ export default function SetupComponent() {
 
   // TODO replace this with proper binding
   function updateForm(data: SettingsResponse) {
-    const fieldSecondsBetweenCaptures = document.getElementById("tfSecondsBetweenCaptures") as HTMLInputElement | null
-    const fieldOffset = document.getElementById("tfOffset") as HTMLInputElement | null
-    const fieldRotation = document.getElementById("tfRotation") as HTMLInputElement | null
-    const fieldQuality = document.getElementById("tfQuality") as HTMLInputElement | null
+    const fieldSecondsBetweenCaptures = document.getElementById("tfSecondsBetweenCaptures")! as HTMLInputElement
+    const fieldOffset = document.getElementById("tfOffset")! as HTMLInputElement
+    const fieldRotation = document.getElementById("tfRotation")! as HTMLInputElement
+    const fieldQuality = document.getElementById("tfQuality")! as HTMLInputElement
 
-    if (fieldSecondsBetweenCaptures) {
-      fieldSecondsBetweenCaptures.value = (data.SecondsBetweenCaptures / 60).toString();
-    }
-    if (fieldOffset) {
-      fieldOffset.value = data.OffsetWithinHour.toString();
-    }
-    if (fieldRotation) {
-      fieldRotation.value = data.RotateBy.toString();
-    }
-    if (fieldQuality) {
-      fieldQuality.value = data.Quality.toString();
-    }
+    fieldSecondsBetweenCaptures.value = (data.SecondsBetweenCaptures / 60).toString();
+    fieldOffset.value = data.OffsetWithinHour.toString();
+    fieldRotation.value = data.RotateBy.toString();
+    fieldQuality.value = data.Quality.toString();
   }
 
   const handleOffsetChanged = (e: ChangeEvent<HTMLInputElement>) => setState(Object.assign(state, { OffsetWithinHour: parseInt(e.target.value) as number }));
@@ -89,10 +81,10 @@ export default function SetupComponent() {
           <TextField id="tfSecondsBetweenCaptures" type="number" onChange={handleTimeBetweenCapturesChanged} defaultValue={state.SecondsBetweenCaptures/60} inputProps={{ inputMode: 'numeric', pattern: '[0-9]+' }} />
         </Grid>
         <Grid item xs={6}>
-          <Typography gutterBottom>Delay within value hour before first capture (minutes):</Typography>
+          <Typography gutterBottom>Delay within the hour before the first capture or -1 to disable (minutes):</Typography>
         </Grid>
         <Grid item xs={6}>
-          <TextField id="tfOffset" type="number" defaultValue={state.OffsetWithinHour} onChange={handleOffsetChanged} inputProps={{ inputMode: 'numeric', pattern: '[0-9]+' }} />
+          <TextField id="tfOffset" type="number" defaultValue={state.OffsetWithinHour} onChange={handleOffsetChanged} inputProps={{ inputMode: 'numeric', pattern: '-?[0-9]+' }} />
         </Grid>
         <Grid item xs={6}>
           <Typography gutterBottom>Photo Resolution (pixels)</Typography>

--- a/timelapse/timelapse.go
+++ b/timelapse/timelapse.go
@@ -41,8 +41,10 @@ func (t Timelapse) CapturePeriodically() {
 					s, err := camera.Capture()
 					if err != nil {
 						log.Printf("Error during capture: %s\n", err.Error())
+					} else {
+						log.Printf("Photo stored in '%s'\n", s)
 					}
-					log.Printf("Photo stored in '%s'. Will sleep for %d seconds.\n", s, t.Settings.SecondsBetweenCaptures)
+					log.Printf("Sleeping for %d seconds.\n", t.Settings.SecondsBetweenCaptures)
 				}
 				time.Sleep(time.Duration(t.Settings.SecondsBetweenCaptures) * time.Second)
 			}

--- a/timelapse/timelapse_test.go
+++ b/timelapse/timelapse_test.go
@@ -38,11 +38,10 @@ func TestSecondsToSleepUntilOffset2(t *testing.T) {
 		},
 	}
 
-	loc := time.Now().Location()
-	ensure.DeepEqual(t, 29*60-1, tl.secondsToSleepUntilOffset(abbrevTime{year: 2017, month: 12, day: 1, hour: 8, min: 46, sec: 1, location: loc}.toDate()))
-	ensure.DeepEqual(t, 13*60-1, tl.secondsToSleepUntilOffset(abbrevTime{year: 2017, month: 12, day: 1, hour: 8, min: 32, sec: 1, location: loc}.toDate()))
-	ensure.DeepEqual(t, 29*60-1, tl.secondsToSleepUntilOffset(abbrevTime{year: 2017, month: 12, day: 1, hour: 8, min: 16, sec: 1, location: loc}.toDate()))
-	ensure.DeepEqual(t, 7*60-1, tl.secondsToSleepUntilOffset(abbrevTime{year: 2017, month: 12, day: 1, hour: 8, min: 8, sec: 1, location: loc}.toDate()))
+	ensure.DeepEqual(t, 29*60-1, tl.secondsToSleepUntilOffset(abbrevTime{year: 2017, month: 12, day: 1, hour: 8, min: 46, sec: 1, location: time.UTC}.toDate()))
+	ensure.DeepEqual(t, 13*60-1, tl.secondsToSleepUntilOffset(abbrevTime{year: 2017, month: 12, day: 1, hour: 8, min: 32, sec: 1, location: time.UTC}.toDate()))
+	ensure.DeepEqual(t, 29*60-1, tl.secondsToSleepUntilOffset(abbrevTime{year: 2017, month: 12, day: 1, hour: 8, min: 16, sec: 1, location: time.UTC}.toDate()))
+	ensure.DeepEqual(t, 7*60-1, tl.secondsToSleepUntilOffset(abbrevTime{year: 2017, month: 12, day: 1, hour: 8, min: 8, sec: 1, location: time.UTC}.toDate()))
 }
 
 func TestFewPicsPerDay(t *testing.T) {
@@ -54,8 +53,7 @@ func TestFewPicsPerDay(t *testing.T) {
 		},
 	}
 
-	loc := time.Now().Location()
-	ensure.DeepEqual(t, tl.secondsToSleepUntilOffset(abbrevTime{year: 2017, month: 12, day: 1, hour: 8, min: 45, location: loc}.toDate()), 15*60)
+	ensure.DeepEqual(t, tl.secondsToSleepUntilOffset(abbrevTime{year: 2017, month: 12, day: 1, hour: 8, min: 45, location: time.UTC}.toDate()), 15*60)
 }
 
 func TestNoSleepTillBrooklyn(t *testing.T) {

--- a/timelapse/timelapse_test.go
+++ b/timelapse/timelapse_test.go
@@ -38,10 +38,10 @@ func TestSecondsToSleepUntilOffset2(t *testing.T) {
 		},
 	}
 
-	ensure.DeepEqual(t, 29*60-1, tl.getSecondsToFirstCapture(abbrevTime{year: 2017, month: 12, day: 1, hour: 8, min: 46, sec: 1, location: time.UTC}.toDate()))
-	ensure.DeepEqual(t, 13*60-1, tl.getSecondsToFirstCapture(abbrevTime{year: 2017, month: 12, day: 1, hour: 8, min: 32, sec: 1, location: time.UTC}.toDate()))
-	ensure.DeepEqual(t, 29*60-1, tl.getSecondsToFirstCapture(abbrevTime{year: 2017, month: 12, day: 1, hour: 8, min: 16, sec: 1, location: time.UTC}.toDate()))
-	ensure.DeepEqual(t, 7*60-1, tl.getSecondsToFirstCapture(abbrevTime{year: 2017, month: 12, day: 1, hour: 8, min: 8, sec: 1, location: time.UTC}.toDate()))
+	ensure.DeepEqual(t, tl.getSecondsToFirstCapture(abbrevTime{year: 2017, month: 12, day: 1, hour: 8, min: 46, sec: 1, location: time.UTC}.toDate()), 29*60-1)
+	ensure.DeepEqual(t, tl.getSecondsToFirstCapture(abbrevTime{year: 2017, month: 12, day: 1, hour: 8, min: 32, sec: 1, location: time.UTC}.toDate()), 13*60-1)
+	ensure.DeepEqual(t, tl.getSecondsToFirstCapture(abbrevTime{year: 2017, month: 12, day: 1, hour: 8, min: 16, sec: 1, location: time.UTC}.toDate()), 29*60-1)
+	ensure.DeepEqual(t, tl.getSecondsToFirstCapture(abbrevTime{year: 2017, month: 12, day: 1, hour: 8, min: 8, sec: 1, location: time.UTC}.toDate()), 7*60-1)
 }
 
 func TestNoSleepTillBrooklyn(t *testing.T) {

--- a/timelapse/timelapse_test.go
+++ b/timelapse/timelapse_test.go
@@ -25,7 +25,7 @@ func TestSecondsToSleepUntilOffset(t *testing.T) {
 			OffsetWithinHour:       15 * 60,
 		},
 	}
-	s := tl.secondsToSleepUntilOffset(time.Now())
+	s := tl.getSecondsToFirstCapture(time.Now())
 	ensure.True(t, 0 <= s)
 	ensure.True(t, s <= tl.Settings.SecondsBetweenCaptures)
 }
@@ -38,22 +38,10 @@ func TestSecondsToSleepUntilOffset2(t *testing.T) {
 		},
 	}
 
-	ensure.DeepEqual(t, 29*60-1, tl.secondsToSleepUntilOffset(abbrevTime{year: 2017, month: 12, day: 1, hour: 8, min: 46, sec: 1, location: time.UTC}.toDate()))
-	ensure.DeepEqual(t, 13*60-1, tl.secondsToSleepUntilOffset(abbrevTime{year: 2017, month: 12, day: 1, hour: 8, min: 32, sec: 1, location: time.UTC}.toDate()))
-	ensure.DeepEqual(t, 29*60-1, tl.secondsToSleepUntilOffset(abbrevTime{year: 2017, month: 12, day: 1, hour: 8, min: 16, sec: 1, location: time.UTC}.toDate()))
-	ensure.DeepEqual(t, 7*60-1, tl.secondsToSleepUntilOffset(abbrevTime{year: 2017, month: 12, day: 1, hour: 8, min: 8, sec: 1, location: time.UTC}.toDate()))
-}
-
-func TestFewPicsPerDay(t *testing.T) {
-	// TODO prepare test for scenarios where pictures are taken more infrequently e.g. once or few times per day.
-	tl := Timelapse{
-		Settings: conf.Settings{
-			SecondsBetweenCaptures: 60 * 30,
-			OffsetWithinHour:       0,
-		},
-	}
-
-	ensure.DeepEqual(t, tl.secondsToSleepUntilOffset(abbrevTime{year: 2017, month: 12, day: 1, hour: 8, min: 45, location: time.UTC}.toDate()), 15*60)
+	ensure.DeepEqual(t, 29*60-1, tl.getSecondsToFirstCapture(abbrevTime{year: 2017, month: 12, day: 1, hour: 8, min: 46, sec: 1, location: time.UTC}.toDate()))
+	ensure.DeepEqual(t, 13*60-1, tl.getSecondsToFirstCapture(abbrevTime{year: 2017, month: 12, day: 1, hour: 8, min: 32, sec: 1, location: time.UTC}.toDate()))
+	ensure.DeepEqual(t, 29*60-1, tl.getSecondsToFirstCapture(abbrevTime{year: 2017, month: 12, day: 1, hour: 8, min: 16, sec: 1, location: time.UTC}.toDate()))
+	ensure.DeepEqual(t, 7*60-1, tl.getSecondsToFirstCapture(abbrevTime{year: 2017, month: 12, day: 1, hour: 8, min: 8, sec: 1, location: time.UTC}.toDate()))
 }
 
 func TestNoSleepTillBrooklyn(t *testing.T) {
@@ -76,7 +64,7 @@ func testInitialSleepTime(t *testing.T, minute int, second int, expectedSleepTim
 	tl := createTimelapseForTesting(t, 900)
 	theTime := time.Date(2017, time.January, 1, 1, minute, second, 0, time.UTC)
 
-	ensure.DeepEqual(t, tl.secondsToSleepUntilOffset(theTime), expectedSleepTime)
+	ensure.DeepEqual(t, tl.getSecondsToFirstCapture(theTime), expectedSleepTime)
 }
 
 func createTimelapseForTesting(t *testing.T, offsetWithinHourSeconds int) Timelapse {


### PR DESCRIPTION
Especially when only taking pictures every couple hours, the `offset within the hour` may become irrelevant. In such cases, the back-end already supported disabling/ignoring the offset config value. As a result, the Pi would take a picture immediately on startup and from there on, adhere to the configured time between captures (which may be hours). This change allows the disabling from the UI as negative values previously were not allowed.

Also improved test readability slightly via a new `abbrevTime` type.

![disabled-offset](https://user-images.githubusercontent.com/143597/181603330-565ca66d-1cac-416a-ba19-3bc76c236e34.png)